### PR TITLE
Adding a check for concurrent services

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -20,12 +20,8 @@ module.exports = function (grunt) {
   // Checks if ports 9997 to 9999 inclusive are available
   portscanner.findAPortInUse(9997, 9999, '127.0.0.1', function(error, port) {
     // Status is 'open' if currently in use or 'closed' if available
-    if (!error) {
-      if (port) {
+    if (!error && port) {
         throw new Error('Cannot start Services port ' + port + ' is being used.');
-      }
-    } else {
-      console.log('There was an error');
     }
   });
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -5,8 +5,8 @@
  */
 
 // 3rd party
-var easybuild = require('easy-build');
-
+var easybuild = require('easy-build'),
+    portscanner = require('portscanner');
 
 /* -----------------------------------------------------------------------------
  * easy-build
@@ -16,6 +16,18 @@ module.exports = function (grunt) {
 
   // loads library specific tasks
   grunt.loadTasks('build/tasks');
+
+  // Checks if ports 9997 to 9999 inclusive are available
+  portscanner.findAPortInUse(9997, 9999, '127.0.0.1', function(error, port) {
+    // Status is 'open' if currently in use or 'closed' if available
+    if (!error) {
+      if (port) {
+        throw new Error('Cannot start Services port ' + port + ' is being used.');
+      }
+    } else {
+      console.log('There was an error');
+    }
+  });
 
   // easy-build yo!
   easybuild.load(grunt, {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "hapi": "~6.5.1",
     "ws": "~0.4.31",
     "proclaim": "~2.0.0",
-    "sinon": "~1.10.1"
+    "sinon": "~1.10.1",
+    "portscanner": "~1.0.0"
   },
   "license": "MIT"
 }


### PR DESCRIPTION
## Opening this PR to start a discussion, this Code may need to be reworked

To prevent Issue #3 one proposal is, 
Add a portscan that terminates the test if a port is taken


Alternatively, we can rework EasyBuild to check for the process return code, and add a `error()` callback handler to process Teardown in error scenarios.