### PR TITLE
Add safegaurd against zombie socket when changing between networks.

### DIFF
--- a/src/rc-socket.js
+++ b/src/rc-socket.js
@@ -68,6 +68,11 @@ var RcSocket = function (url, protocols) {
     this.unload = true;
   }.bind(this);
 
+  // Protect against network/ip changes.
+  window.addEventListener('offline', function () {
+    this.refresh();
+  });
+
   // Connect dAwG! - delay to add handlers
   setTimeout(this.connect.bind(this), 0);
 };


### PR DESCRIPTION
Wanted to start a discussion around this small patch. Right now we have an issue where network changes are handled silently (except safari, as we know safari sends client PINGS).

The idea here is to say, anytime we are not connected (hopefully detected even if disconnect is for s split second), lets try to refresh the socket. This ensures the socket is always connected based on its current IP.

Issues w/ Implementation
* I have no idea how to write tests for this. I have only been able to manually test at the OS level by toggling my wifi off.
* Dependent on [navigator.onLine](http://caniuse.com/#feat=online-status) which is far from perfect.
* Unaware if the disconnect will be fired when on a mobile device and switching from wifi to carrier.