### PR TITLE
HTML5 Local Storage, Safari Support, Time Sync

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -33,7 +33,7 @@ module.exports = function (grunt) {
     'dev:prehook': ['process:api:start'],
     'dev:posthook': ['process:api:stop'],
 
-    'test:crossbrowser' : ['build', 'assemble', 'connect', 'sauce_tunnel', 'mochaTest', 'sauce_tunnel_stop']
+    'test:crossbrowser' : ['build', 'assemble', 'connect', 'process:api:start', 'sauce_tunnel', 'mochaTest', 'sauce_tunnel_stop', 'process:api:stop']
   });
 
   // Execution order matters

--- a/build/tasks/mocha.js
+++ b/build/tasks/mocha.js
@@ -15,7 +15,7 @@ module.exports = function (grunt) {
   // I am bypassing this test when running on Travis.
   // Hitting a Mocha crash on Travis which is not reproducible locally.
   // [see Build 56](https://travis-ci.org/firstopinion/rc-socket.js/builds/96867654)
-  if (process.env.TRAVIS === true) {
+  if (process.env.SAUCE_USERNAME !== undefined) {
     return;
   }
 

--- a/build/tasks/mocha.js
+++ b/build/tasks/mocha.js
@@ -15,9 +15,9 @@ module.exports = function (grunt) {
   // I am bypassing this test when running on Travis.
   // Hitting a Mocha crash on Travis which is not reproducible locally.
   // [see Build 56](https://travis-ci.org/firstopinion/rc-socket.js/builds/96867654)
-  //if (process.env.SAUCE_USERNAME !== undefined) {
-  //  return;
-  //}
+  if (process.env.TRAVIS === true) {
+    return;
+  }
 
   /* ---------------------------------------------------------------------------
    * load

--- a/build/tasks/mocha.js
+++ b/build/tasks/mocha.js
@@ -15,9 +15,9 @@ module.exports = function (grunt) {
   // I am bypassing this test when running on Travis.
   // Hitting a Mocha crash on Travis which is not reproducible locally.
   // [see Build 56](https://travis-ci.org/firstopinion/rc-socket.js/builds/96867654)
-  if (process.env.SAUCE_USERNAME !== undefined) {
-    return;
-  }
+  //if (process.env.SAUCE_USERNAME !== undefined) {
+  //  return;
+  //}
 
   /* ---------------------------------------------------------------------------
    * load

--- a/test/cross-browser/reference.html
+++ b/test/cross-browser/reference.html
@@ -22,27 +22,6 @@
     <script>
         var clientLogger;
 
-        function createWindowLogger() {
-            var childWin;
-            var child = window.open('', 'childLogger');
-            childWin = child.window;
-
-            if (!childWin.clientLogger) {
-                childWin.clientLogger = {
-                    buffer: [],
-
-                    debug: function () {
-                        childWin.clientLogger.buffer.push({
-                            ts: Date.now(),
-                            message: arguments['0'] + ' ' + arguments['1'] + ' ' + arguments['2']
-                        });
-                    }
-                };
-            }
-
-            return childWin.clientLogger;
-        }
-
         function createLocalStorageLogger() {
             return {
                 debug: function() {
@@ -56,11 +35,9 @@
 
         var createRcSocket = function() {
             if(typeof(Storage) !== "undefined") {
-                // Code for localStorage/sessionStorage.
                 clientLogger = createLocalStorageLogger();
             } else {
-                // no Web Storage support, fallback to Child Window buffer
-                clientLogger = createWindowLogger();
+                console.log("no Web Storage support");
             }
 
             var rc = new RcSocket("ws://localhost:9998/");

--- a/test/cross-browser/reference.html
+++ b/test/cross-browser/reference.html
@@ -12,8 +12,6 @@
         <!--<link rel="stylesheet" href="../node_modules/easy-build/node_modules/mocha/mocha.css" />-->
     </head>
 
-    <!--<script src="http://cdnjs.cloudflare.com/ajax/libs/loglevel/1.4.0/loglevel.min.js"></script>-->
-
     <!-- content -->
     <div id="workboard" style="position: absolute;"></div>
     <div id="mocha">
@@ -22,9 +20,10 @@
 
     <!-- traces -->
     <script>
-        var childWin;
+        var clientLogger;
 
-        var createRcSocket = function() {
+        function createWindowLogger() {
+            var childWin;
             var child = window.open('', 'childLogger');
             childWin = child.window;
 
@@ -32,24 +31,72 @@
                 childWin.clientLogger = {
                     buffer: [],
 
-                    debug: function() {
+                    debug: function () {
                         childWin.clientLogger.buffer.push({
                             ts: Date.now(),
                             message: arguments['0'] + ' ' + arguments['1'] + ' ' + arguments['2']
                         });
-                    }
+                    },
+
+                    dump: function () {
+                        return this.buffer;
+                    },
+
+                    clear: function () { }
                 };
             }
 
+            return childWin.clientLogger;
+        }
+
+        function createLocalStorageLogger() {
+            return {
+                debug: function() {
+                    localStorage.setItem(
+                        String(Date.now()),
+                        arguments['0'] + ' ' + arguments['1'] + ' ' + arguments['2']
+                    );
+                },
+
+                dump: function () {
+                    var buffer = [];
+                    for (var i = 0; i < localStorage.length; i++) {
+                        buffer.push({
+                            ts: parseInt(localStorage.key(i)),
+                            message: localStorage.getItem(localStorage.key(i))
+                        });
+                    }
+
+                    return buffer;
+                },
+
+                clear: function () {
+                    localStorage.clear();
+                    this.dump = function() {}
+                }
+            }
+        }
+
+        var createRcSocket = function() {
+            if(typeof(Storage) !== "undefined") {
+                // Code for localStorage/sessionStorage.
+                clientLogger = createLocalStorageLogger();
+            } else {
+                // no Web Storage support, fallback to Child Window buffer
+                clientLogger = createWindowLogger();
+            }
+
             var rc = new RcSocket("ws://localhost:9998/");
-            rc.logger = childWin.clientLogger.debug;
+            rc.logger = clientLogger.debug;
             rc.debug = true;
+
             return rc;
         };
 
+        // Start RcSocket onLoad if the 'immediate' URL param is set
         if (window.location.search.replace("?", "").length) {
             createRcSocket();
-            childWin.clientLogger.debug('RcSocket', 'startSocketImmediately', ' ');
+            clientLogger.debug('RcSocket', 'startSocketImmediately', ' ');
         }
     </script>
 

--- a/test/cross-browser/reference.html
+++ b/test/cross-browser/reference.html
@@ -36,13 +36,7 @@
                             ts: Date.now(),
                             message: arguments['0'] + ' ' + arguments['1'] + ' ' + arguments['2']
                         });
-                    },
-
-                    dump: function () {
-                        return this.buffer;
-                    },
-
-                    clear: function () { }
+                    }
                 };
             }
 
@@ -56,23 +50,6 @@
                         String(Date.now()),
                         arguments['0'] + ' ' + arguments['1'] + ' ' + arguments['2']
                     );
-                },
-
-                dump: function () {
-                    var buffer = [];
-                    for (var i = 0; i < localStorage.length; i++) {
-                        buffer.push({
-                            ts: parseInt(localStorage.key(i)),
-                            message: localStorage.getItem(localStorage.key(i))
-                        });
-                    }
-
-                    return buffer;
-                },
-
-                clear: function () {
-                    localStorage.clear();
-                    this.dump = function() {}
                 }
             }
         }
@@ -91,6 +68,18 @@
             rc.debug = true;
 
             return rc;
+        };
+
+        var dumpLogger = function() {
+            var buffer = [];
+            for (var i = 0; i < localStorage.length; i++) {
+                buffer.push({
+                    ts: parseInt(localStorage.key(i)),
+                    message: localStorage.getItem(localStorage.key(i))
+                });
+            }
+
+            return buffer;
         };
 
         // Start RcSocket onLoad if the 'immediate' URL param is set

--- a/test/cross-browser/report.js
+++ b/test/cross-browser/report.js
@@ -169,6 +169,8 @@ var synchronizeTimestamps = function() {
         .executeScript('return Date.now();')
         .then(function(d) {
             tsOffset = Date.now() - d;
+
+            console.log('## Timestamp Offset ' + tsOffset)
         });
 };
 

--- a/test/cross-browser/report.js
+++ b/test/cross-browser/report.js
@@ -55,12 +55,20 @@ var buildDriver = function () {
                 build: process.env.TRAVIS_BUILD_NUMBER,
                 username: process.env.SAUCE_USERNAME,
                 accessKey: process.env.SAUCE_ACCESS_KEY,
-                browserName: 'firefox'
+                //platform: 'Windows 7',
+                //browserName: 'firefox',
+                //version: '',
+                platform: 'OS X 10.11',
+                browserName: 'safari',
+                version: '9.0',
+                //version: '11',
+                //browserName: 'internet explorer'
             }).build();
     } else {
         driver = new webdriver.Builder()
             .withCapabilities({
-                browserName: 'chrome'
+                //browserName: 'chrome'
+                browserName: 'safari'
                 //browserName: suite.options.browserArgument
             })
             .build();
@@ -213,7 +221,7 @@ var lostNetworkLink = function() {
 
 describe('RcSocketIntegration', function () {
 
-    this.timeout(10000);
+    this.timeout(10000 * 3);
 
     beforeEach(function () {
         return startServerSocket()

--- a/test/cross-browser/report.js
+++ b/test/cross-browser/report.js
@@ -170,7 +170,7 @@ var synchronizeTimestamps = function() {
         .then(function(d) {
             tsOffset = Date.now() - d;
 
-            console.log('## Timestamp Offset ' + tsOffset)
+            console.log('## Timestamp Offset ' + tsOffset);
         });
 };
 

--- a/test/cross-browser/report.js
+++ b/test/cross-browser/report.js
@@ -30,23 +30,12 @@ var clearLogger = function() {
 };
 
 var logMessage = function(msg) {
-    var timestampPromise = Q.fcall(function() {
-        return Date.now() + tsOffset;
-    });
-
-    //if (typeof driver !== 'undefined') {
-    //    timestampPromise = driver.executeScript('return Date.now();');
-    //}
-
-    return timestampPromise
-        .then(function(d) {
-            var z = {
-                ts: d,
-                message: msg
-            };
-
-            return logger.push(z);
+    return Q.fcall(function() {
+        return logger.push({
+            ts: Date.now() + tsOffset,
+            message: msg
         });
+    });
 };
 
 /* -----------------------------------------------------------------------------
@@ -77,9 +66,9 @@ var buildDriver = function () {
     } else {
         driver = new webdriver.Builder()
             .withCapabilities({
-                //browserName: 'phantomjs'
-                browserName: 'chrome'
                 //browserName: 'safari'
+                browserName: 'chrome'
+                //browserName: 'firefox'
                 //browserName: suite.options.browserArgument
             })
             .build();
@@ -101,39 +90,6 @@ var closeWindow = function () {
     logMessage('Runner closeWindow');
 
     return driver.close();
-};
-
-var getAllHandles = function () {
-    return driver.getAllWindowHandles();
-};
-
-var getParentHandle = function () {
-    return getAllHandles()
-        .then(function (handles) {
-            return handles[0];
-        });
-};
-
-var getChildHandle = function () {
-    return getAllHandles()
-        .then(function (handles) {
-            //return the last handle
-            return handles.slice(-1)[0];
-        });
-};
-
-var getParentWindow = function () {
-    return getParentHandle()
-        .then(function (handle) {
-            return driver.switchTo().window(handle);
-        });
-};
-
-var getChildWindow = function () {
-    return getChildHandle()
-        .then(function (handle) {
-            return driver.switchTo().window(handle);
-        });
 };
 
 var loadClient = function() {

--- a/test/cross-browser/report.js
+++ b/test/cross-browser/report.js
@@ -77,8 +77,9 @@ var buildDriver = function () {
     } else {
         driver = new webdriver.Builder()
             .withCapabilities({
-                //browserName: 'chrome'
-                browserName: 'safari'
+                //browserName: 'phantomjs'
+                browserName: 'chrome'
+                //browserName: 'safari'
                 //browserName: suite.options.browserArgument
             })
             .build();


### PR DESCRIPTION
Safari was a browser that was having issues with the Client Window logging mechanism that we initially had. With this PR I've now added Local Storage logging, and the supporting runner changes.

The Timestamp synchronization was an attempt at working around the SauceLabs timing stuff, its still work in progress.

Let me know which commits to squash.  The `Mocha Exploded on Travis` commit is backing out the changes in `Using appropriate flag for Travis check`.